### PR TITLE
Run CI on all supported architectures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,22 @@ services:
   - docker
 
 before_install:
-  - docker pull fedorapython/fedora-python-tox
+  - docker pull fedorapython/fedora-python-tox:latest
+  - docker inspect fedorapython/fedora-python-tox:latest
   - docker images
 
 script:
-  - docker run --rm -it -v $PWD:/src -w /src -e TOXENV fedorapython/fedora-python-tox
+  - docker run --rm -v $PWD:/src -w /src -e TOXENV fedorapython/fedora-python-tox
 
 # Unfortunately, this matrix has to updated manually every time
 # we add or remove a tox environment.
-# To get the list run `tox -l | sed "s/^/  - env: TOXENV=/"`
 matrix:
   include:
-  - env: TOXENV=py36
-  - env: TOXENV=py37
-  - env: TOXENV=py38
-  - env: TOXENV=py39
+  - env: TOXENV=py36,py37,py38,py39
+    arch: amd64
+  - env: TOXENV=py36,py37,py38,py39
+    arch: arm64
+  - env: TOXENV=py36,py37,py38,py39
+    arch: ppc64le
+  - env: TOXENV=py36,py37,py38,py39
+    arch: s390x

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: required
 
 services:
   - docker


### PR DESCRIPTION
Since our multiarch docker image is already available on Docker hub, we can use it to test the parser on all supported architectures.

The arm64 job takes more than 40 minutes but I'd say it's worth it to catch all possible problems early.