### PR TITLE
Add Python 3.11 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,14 @@ script:
 # we add or remove a tox environment.
 matrix:
   include:
-  - env: TOXENV=py36,py37,py38,py39,py310,black,mypy
+  - env: TOXENV=py36,py37,py38,py39,py310,py311,black,mypy
     arch: amd64
-  - env: TOXENV=py36,py38,py39,py310
+  # Arm is slow so we use two separated jobs for it
+  - env: TOXENV=py36,py37,py38
     arch: arm64
-  - env: TOXENV=py36,py37,py38,py39,py310
+  - env: TOXENV=py39,py310,py311
+    arch: arm64
+  - env: TOXENV=py36,py37,py38,py39,py310,py311
     arch: ppc64le
-  - env: TOXENV=py36,py37,py38,py39,py310
+  - env: TOXENV=py36,py37,py38,py39,py310,py311
     arch: s390x

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
 
 [testenv:black]
 deps=black
-commands=black --check --diff .
+commands=black --check --diff --extend-exclude=".tox|test" ./
 
 [testenv:mypy]
 deps=mypy

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = black,mypy,py{36,37,38,39,310}
+envlist = black,mypy,py{36,37,38,39,310,311}
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
Separated from the PR bringing 3.11 support to marshalparser because we have to wait till Python 3.11 is in Fedora to test it in the CI.