### PR TITLE
Update tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist = black,mypy,py{36,37,38,39,310,311}
-skipsdist = True
+isolated_build = True
 
 [testenv]
 commands =
@@ -8,7 +8,6 @@ commands =
     pytest -v {posargs} test.py
 deps =
     pytest
-    py36: dataclasses  # dataclasses module is in stdlib in 3.7+
 
 [testenv:black]
 deps=black


### PR DESCRIPTION
If we remove skipsdist from tox.ini we don't need to specify the runtime dependency for Python 3.6 manually.