### PR TITLE
In tox, run pytest with xdist

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,12 @@ isolated_build = True
 [testenv]
 commands =
     python -m platform
-    pytest {posargs}
+    pytest -n auto {posargs}
 extras =
     test
+deps =
+    # this is deliberately not in the test extra, as it is not required:
+    pytest-xdist
 
 [testenv:black]
 deps=black


### PR DESCRIPTION
That way, plain pytest usage does not need it, and hence it is not listed in the [test] extra.
