### PR TITLE
fix: message typo

### DIFF
--- a/marshalparser/marshalparser.py
+++ b/marshalparser/marshalparser.py
@@ -113,7 +113,7 @@ class MarshalParser:
             type = types[bytestring]
         except KeyError:
             print(
-                f"Cannot read/parse byte {b!r} {bytestring!r} on possition {i}"
+                f"Cannot read/parse byte {b!r} {bytestring!r} on position {i}"
             )
             print("Might be error or unsupported TYPE")
             print(self.output)


### PR DESCRIPTION
Fix typo in error message when failing to parse